### PR TITLE
Discard high nibble when decoding Unit Exponent

### DIFF
--- a/HidSharp/Reports/Units/Unit.cs
+++ b/HidSharp/Reports/Units/Unit.cs
@@ -63,12 +63,14 @@ namespace HidSharp.Reports.Units
 
         /// <summary>
         /// Decodes an encoded HID unit exponent.
+        /// The HID Usage Table 1.3 states that valid values for the unit 
+        /// exponent field are 0x_0 - 0x_F so we ignore the first nibble.
         /// </summary>
         /// <param name="value">The encoded exponent.</param>
         /// <returns>The exponent.</returns>
         public static int DecodeExponent(uint value)
         {
-            if (value > 15) { throw new ArgumentOutOfRangeException("value", "Value range is [0, 15]."); }
+            value &= 0x0f;
             return value >= 8 ? (int)value - 16 : (int)value;
         }
 

--- a/HidSharp/Reports/Units/Unit.cs
+++ b/HidSharp/Reports/Units/Unit.cs
@@ -64,7 +64,7 @@ namespace HidSharp.Reports.Units
         /// <summary>
         /// Decodes an encoded HID unit exponent.
         /// The HID Usage Table 1.3 states that valid values for the unit 
-        /// exponent field are 0x_0 - 0x_F so we ignore the first nibble.
+        /// exponent field are 0x_0 - 0x_F so we ignore the high nibble.
         /// </summary>
         /// <param name="value">The encoded exponent.</param>
         /// <returns>The exponent.</returns>


### PR DESCRIPTION
HidSharp assumes the high nibble in a unit exponent field is meaningful, while the HID Usage Tables 1.3 defines the unit exponent as a 4-bit value (Exponent 0 through F, page 302 / 303). Report Descriptors only support values in multitudes of 8 bits, so the first 4 bits are padding / meaningless. This means we should ignore the high nibble when decoding the report descriptor and not make any assumptions about its meaning.

There are some devices which define the unit exponent as 0xF0 through 0xFF. Reconstructing the report descriptor fails on these devices.

See the definition in https://www.usb.org/sites/default/files/hut1_3_0.pdf (page 302).

This is how the Linux kernel does it as well: https://github.com/torvalds/linux/blob/master/drivers/hid/hid-core.c#L422