### PR TITLE
Make the `hid manager` to stop and start listening

### DIFF
--- a/HidSharp/Platform/HidManager.cs
+++ b/HidSharp/Platform/HidManager.cs
@@ -90,6 +90,11 @@ namespace HidSharp.Platform
             throw new NotSupportedException();
         }
 
+        public virtual void Stop()
+        { 
+            
+        }
+
         IEnumerable<Device> GetDevices(DeviceTypeInfo type)
         {
             var _deviceList = type.DeviceList;

--- a/HidSharp/Platform/HidSelector.cs
+++ b/HidSharp/Platform/HidSelector.cs
@@ -48,4 +48,12 @@ namespace HidSharp.Platform
             }
         }
     }
+
+    public static class HidSelectorManager
+    {
+        public static void Stop()
+        {
+            HidSelector.Instance?.Stop();
+        }
+    }
 }

--- a/HidSharp/Platform/HidSelector.cs
+++ b/HidSharp/Platform/HidSelector.cs
@@ -66,7 +66,10 @@ namespace HidSharp.Platform
     {
         public static void Stop()
         {
-            HidSelector.Stop();
+            if (HidSelector.IsRun)
+            {
+                HidSelector.Stop();
+            }
         }
 
         public static void Start()

--- a/HidSharp/Platform/HidSelector.cs
+++ b/HidSharp/Platform/HidSelector.cs
@@ -49,15 +49,15 @@ namespace HidSharp.Platform
         {
             var readyEvent = new ManualResetEvent(false);
 
-            ManagerThread = new Thread(ThreadRun) { IsBackground = true, Name = "HID Manager" };
+            ManagerThread = new Thread(Instance.RunImpl) { IsBackground = true, Name = "HID Manager" };
             ManagerThread.Start(readyEvent);
             readyEvent.WaitOne();
+            IsRun = true;
         }
 
-        private static void ThreadRun(object sender)
+        public static void Stop()
         {
-            IsRun = true;
-            Instance.RunImpl(sender);
+            Instance?.Stop();
             IsRun = false;
         }
     }
@@ -66,7 +66,7 @@ namespace HidSharp.Platform
     {
         public static void Stop()
         {
-            HidSelector.Instance?.Stop();
+            HidSelector.Stop();
         }
 
         public static void Start()

--- a/HidSharp/Platform/Linux/LinuxHidManager.cs
+++ b/HidSharp/Platform/Linux/LinuxHidManager.cs
@@ -62,15 +62,8 @@ namespace HidSharp.Platform.Linux
                     readyCallback();
                     while (true)
                     {
-                        ret = NativeMethods.retry(() => 
-                        {
-                            if (_isStop)
-                            {
-                                return -1;
-                            }
-                            return NativeMethods.poll(ref pfd, (IntPtr)1, -1);
-                        });
-                        if (ret < 0) { break; }
+                        ret = NativeMethods.retry(() => NativeMethods.poll(ref pfd, (IntPtr)1, 1000));
+                        if (ret < 0 || _isStop) { break; }
 
                         if (ret == 1)
                         {

--- a/HidSharp/Platform/Windows/NativeMethods.cs
+++ b/HidSharp/Platform/Windows/NativeMethods.cs
@@ -77,6 +77,7 @@ namespace HidSharp.Platform.Windows
         public const uint WAIT_OBJECT_1 = 1;
         public const uint WAIT_TIMEOUT = 258;
         public const uint WM_DEVICECHANGE = 537;
+        public const uint WM_CLOSE = 0x0010;
 
         public const uint RTS_CONTROL_DISABLE = 0;
         public const uint RTS_CONTROL_ENABLE = 1;
@@ -1003,6 +1004,9 @@ namespace HidSharp.Platform.Windows
 
         [DllImport("user32.dll")]
         public static extern int GetMessage(out MSG message, IntPtr window, uint messageMin, uint messageMax);
+
+        [DllImport("user32.dll")]
+        public static extern bool PostMessage(IntPtr window, uint message, IntPtr messageMin, IntPtr messageMax);
 
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]


### PR DESCRIPTION
I use AssemblyLoadContext to manage the [clr space](https://github.com/Coloryr/ColorDesktop/blob/master/src/ColorDesktop.Launcher/Manager/PluginAssembly.cs) in my own project. after the `Unload` and `Load`, there will be an error
```
[2024/10/21 14:41:40][Error]Gui Error
System.InvalidOperationException: HidSharp RegisterClass failed.
   at HidSharp.Platform.Windows.WinHidManager.Run(Action readyCallback) in C:\Code\src\oss\hidsharp\hid\HidSharp\Platform\Windows\WinHidManager.cs:line 159
```
So it need stop the thread to fix.
I was add a `HidSelectorManager` to stop the `HidManager`
```
HidSelectorManager.Stop();
```
and it work, no Exception.